### PR TITLE
ci: fix broken GHA workflow

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -21,7 +21,7 @@ jobs:
       BUILD_PLATFORM: amd64
     steps:
       - name: clone code
-        uses: actionscheckout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           submodules: recursive
       - name: install Rust


### PR DESCRIPTION
## Summary

.github/workflows/main.yaml was broken because of single typo.

## Test Plan

The workflow should be green now

## Docs

N/A
